### PR TITLE
ActiveHushの修正②

### DIFF
--- a/app/models/shipping_day.rb
+++ b/app/models/shipping_day.rb
@@ -3,7 +3,7 @@ class ShippingDay < ActiveHash::Base
     { id: 1, name: '---' },
     { id: 2, name: '1~2日で発送' },
     { id: 3, name: '2~3日で発送' },
-    { id: 4, name: '4〜７日で発送' }
+    { id: 4, name: '4~７日で発送' }
   ]
 
   include ActiveHash::Associations


### PR DESCRIPTION
# What
ActiveHushの修正②

# Why
発送日数の「〜」表記を統一するため